### PR TITLE
Support converting multiple sp_executesql statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.0.3] - 2020-06-29 - @gerneio
+### Enhancement
+- Support converting multiple sp_executesql statements [#6](https://github.com/PejmanNik/sqlops-spexecutesql-to-sql/pull/6)
+
 ## [1.0.2] - 2020-01-04
 ### Fixed
 - fix bug in parsing double quote in the query

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Inspiring from https://github.com/mattwoberts/execsqlformat. so Thank you @mattw
 
 ## Release Notes
 
+## [1.0.3] - 2020-06-29 - @gerneio
+### Enhancement
+- Support converting multiple sp_executesql statements [#6](https://github.com/PejmanNik/sqlops-spexecutesql-to-sql/pull/6)
+
 ## [1.0.2] - 2020-01-04
 ### Fixed
 - fix bug in parsing double quote in the query

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "sqlops-spexecutesql-to-sql",
     "displayName": "sqlops-spexecutesql-to-sql",
     "description": "sp_executesql to sql",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "pejmannikram",
     "icon": "images/icon.png",
     "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,17 +22,25 @@ export function activate(context: vscode.ExtensionContext) {
           );
         };
 
-        const regex = /(?:exec)*\s*sp_executesql\s+N'([\s\S]*)'\s*,\s*N'(@[\s\S]*?)'\s*,\s*([\s\S]*)/;
-        const text = textEditor.document.getText();
-        const match = regex.exec(text);
+        const regex = /(?:exec)*\s*sp_executesql\s*N'([\s\S]*?)'\s*,\s*N'(@[\s\S]*?)'\s*,\s*([\s\S]*?$)/mg
 
-        if (match) {
+        const text = textEditor.document.getText();
+        var replacedText = text;
+        var match = regex.exec(text);
+
+        // Iterate over all matches
+        while (match != null) {
           // convert sp_executesql query to sql query
           const newText = parseQuery(match[2], match[3], match[1]);
+          replacedText = replacedText.replace(match[0], newText);
 
+          match = regex.exec(text);
+        }
+
+        if (text != replacedText) {
           await textEditor.edit(
             (editBuilder: vscode.TextEditorEdit) => {
-              editBuilder.replace(getFullRange(), newText);
+              editBuilder.replace(getFullRange(), replacedText);
             },
             { undoStopBefore: true, undoStopAfter: false }
           );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
           );
         };
 
-        const regex = /(?:exec)*\s*sp_executesql\s*N'([\s\S]*?)'\s*,\s*N'(@[\s\S]*?)'\s*,\s*([\s\S]*?$)/mg
+        const regex = /(?:\bexec|\bexecute)*\s*sp_executesql\s*N'([\s\S]*?)'\s*,\s*N'(@[\s\S]*?)'\s*,\s*([\s\S]*?$)/mgi;
 
         const text = textEditor.document.getText();
         var replacedText = text;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,6 +11,8 @@ function parseQuery(
   let result = "DECLARE " + parameterDeclaration + "\n";
 
   parameterValue.split(",").forEach((value, index) => {
+    value = value.trim();
+
     if (value[0] !== "@") {
       value = parameters[index].split(" ")[0] + "=" + value;
     }


### PR DESCRIPTION
... and does not improperly overwrite other non-sp_executesql formatted queries. The goal of this PR is to allow a user to work with a whole set of SQL statements in ONE file and, regardless of their origin, convert only the necessary bits.

Tested in VSCODE dev environment.